### PR TITLE
Fix: xl settings for grid

### DIFF
--- a/src/Column.vue
+++ b/src/Column.vue
@@ -99,6 +99,7 @@ export default {
 
 @media (min-width: 1200px) {
   .colVGR-xl {
+    flex-basis: var(--xlWidthVGR);
     max-width: var(--xlWidthVGR);
   }
 }


### PR DESCRIPTION
Hey @andrelmlins , 

we recently added this package to a vue application and experienced an error with the xl-grid settings, where only the "lg" settings for a column were used, even if the resolution exeeded the max breakpoint size.

## How to reproduce:
Paste this into any empty template:

```
<div>
    <row :gutter="0" style="{ height: '500px' }">
      <column :sm="1" :md="1" :lg="6" :xl="4" :style="{ backgroundColor: 'blue', height: '500px' }"></column>
      <column :sm="1" :md="1" :lg="6" :xl="8" :style="{ backgroundColor: 'red', height: '500px' }"></column>
    </row>
  </div>
```
 
You will see something like this, where there is still some white space. This should not be the case. The grid does fill 100% of the page, but the columns do not use all the available space.


<img width="1201" alt="Bildschirmfoto 2021-04-14 um 14 53 27" src="https://user-images.githubusercontent.com/7706509/114713875-d6f0dd80-9d31-11eb-98d9-fde11cc7df6a.png">

## Problem

Even if the breakpoint for lg is exceeded and the xl-settings should be shown for grid-columns, the lg-settings are still active. 
This is, because the `flex-basis` for xl is not set and therefore the lg-settings for `flex-basis` are still active.

<img width="236" alt="Bildschirmfoto 2021-04-14 um 14 53 42" src="https://user-images.githubusercontent.com/7706509/114715010-efadc300-9d32-11eb-8e8a-7ac645ab2eb8.png">


## Solution

Add `flex-basis` for xl-settings as well.

## Result
<img width="236" alt="Bildschirmfoto 2021-04-14 um 15 07 08" src="https://user-images.githubusercontent.com/7706509/114715213-208df800-9d33-11eb-970d-3eb22100654c.png">

<img width="1205" alt="Bildschirmfoto 2021-04-14 um 15 07 03" src="https://user-images.githubusercontent.com/7706509/114715183-179d2680-9d33-11eb-90ef-137c104e0d5e.png">



Cheers, Dennis for NanoGiants
