### PR TITLE
Replace computed instead of method

### DIFF
--- a/src/Row.vue
+++ b/src/Row.vue
@@ -14,17 +14,12 @@ export default {
       default: 12,
     },
   },
-  data() {
-    return {
-      styleGeneral: this.createGutter(this.gutter),
-    };
-  },
-  methods: {
-    createGutter(gutter) {
-      return gutter
-        ? `--paddingVGR:${gutter / 2}px;--marginVGR:-${gutter / 2}px`
-        : '--paddingVGR:0px;--marginVGR:0px';
-    },
+  computed: {
+    styleGeneral() {
+      return this.gutter
+          ? `--paddingVGR:${this.gutter / 2}px;--marginVGR:-${this.gutter / 2}px`
+          : '--paddingVGR:0px;--marginVGR:0px';
+    }
   },
 };
 </script>


### PR DESCRIPTION
- In my `Nuxt` project, using of `method` doesn't work. So I had to use `computed`.
- Also creating a computed property is the best thing when we need to reference a value from the template because it’s cached.